### PR TITLE
Switch to npm pack and publish via github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on: 
+  release:
+   types: [published]
+  push:
+    branches:
+      - 'lester/*'
+
+jobs:
+  publish-to-github-packages:
+    permissions:
+      packages: write
+      contents: read
+    uses: millicast/github-actions/.github/workflows/npm-publish.yml@main
+    with:
+      registry-url: 'https://registry.npmjs.org/'
+    secrets:
+      token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
    types: [published]
 
 jobs:
-  publish-to-github-packages:
+  publish-npmjs:
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish
 on: 
-  release:
-   types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish-npmjs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish
 on: 
   release:
    types: [published]
-  push:
-    branches:
-      - 'lester/*'
 
 jobs:
   publish-to-github-packages:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "swig": "swig -javascript -node -c++ src/audio-codecs.i",
     "build": "node-gyp build --jobs=max",
     "install": "test -f build/Release/medooze-audio-codecs.node || (node-gyp configure && node-gyp rebuild --jobs=max)",
-    "package": "npm run prepare && tar cvzf build/medooze-audio-codecs.tgz  `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-audio-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-audio-codecs/|\"` media-server/src/* media-server/include/* media-server/ext/libdatachannels/src/* media-server/ext/crc32c/* lib/* package.json index.js index.d.ts build/types  binding.gyp  README.md src",
     "dist": "npm run configure && npm run build && npm run prepare && mkdir -p dist && tar cvzf dist/medooze-audio-codecs-`node -e 'console.log(require(\"./package.json\").version)'`.tgz `([ \"$(uname)\" = 'Darwin' ] && echo \"-s |^|medooze-audio-codecs/|\") || echo \" --transform=flags=r;s|^|medooze-audio-codecs/|\"` package.json index.js index.d.ts build/types  README.md lib/* build/Release/medooze-audio-codecs.node",
     "test": "tap tests/*.js --cov --no-check-coverage"
   },

--- a/package.json
+++ b/package.json
@@ -35,5 +35,19 @@
     "@types/node": "^20.8.6",
     "@types/uuid": "^9.0.5",
     "typescript": "^5.2.2"
-  }
+  },
+  "files": [
+    "media-server/src/*",
+    "media-server/include/*",
+    "media-server/ext/libdatachannels/src/*",
+    "media-server/ext/crc32c/*",
+    "lib/*",
+    "package.json",
+    "index.js",
+    "index.d.ts",
+    "build/types",
+    "binding.gyp",
+    "README.md",
+    "src"
+  ]
 }


### PR DESCRIPTION
Switches to use `npm pack` instead of the package run-script. Only diff between the tarballs is that npm pack includes all Licenses and Readmes

![image](https://github.com/medooze/audio-codecs-node/assets/145613755/5f2201bd-320e-4a59-8bf8-e03b7ba6635c)

Sample publishing job: https://github.com/medooze/audio-codecs-node/actions/runs/9025637331/job/24801668454?pr=11